### PR TITLE
Add ToS and privacy policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 This auto-complete functionality can be installed to your entire GitHub account, a GitHub org, or a subset of repositories that you have push permission to.
 
+Please read our [privacy policy](doc/privacy_policy.md) and our [terms of use](doc/terms_of_use.md) before getting started.
+We wrote them ourselves, so they are short and easy reading. :)
+
 **[Install the Github App](https://github.com/apps/pr-autocomplete)** and designate which account(s) and/or repo(s) should get the functionality.
 
 At installation, a few labels will be created in each repository so you can conveniently add them to your pull requests. These labels are described below. You may delete (and even later recreate) these labels as desired to suit the policies you follow regarding the completion of pull requests.

--- a/doc/privacy_policy.md
+++ b/doc/privacy_policy.md
@@ -1,0 +1,32 @@
+# Privacy Policy
+
+## What we store
+
+This GitHub app does NOT retrieve or store:
+
+* Your user accounts
+* Your source code
+
+What we *do* store:
+
+* Logs for incoming GitHub hooks are temporarily persisted in our Azure Storage account.
+  These logs may include your repo URL, account names, metadata about your PR status, etc.
+  The logs are only used for failure analysis and are periodically purged.
+
+To provide better auto-completion of pull requests, we may store in the future:
+
+* State regarding active pull requests
+* Relevant repo metadata including whether your repo tends to add build validation to each PR.
+  This is expected to help resolve #27 due to a limitation in the GitHub API.
+
+## What we may access
+
+In response to events from your repo's pull requests, we use GitHub APIs to read pull request metadata including but not limited to:
+
+* Checks status
+* Labels
+* Mergeability
+* Reviewer status
+
+We may also read/post PR comments in the future in order to improve interactions with repo contributors
+and provide status as to when/whether the PR will be auto-completed.

--- a/doc/terms_of_use.md
+++ b/doc/terms_of_use.md
@@ -1,0 +1,6 @@
+# Terms of use
+
+**IMPORTANT: Use this app at your own risk.**
+
+This app is hosted and offered to service your repos at no cost to you.
+It is maintained by open source developers who want to share a useful app that we use ourselves, but we cannot take responsibility for misbehaviors of the app due to bugs, negligence, or any other reason.


### PR DESCRIPTION
In preparation for a public listing on the GitHub Marketplace, we need to add terms of service and privacy policy pages.